### PR TITLE
Explicitly state interpreter for build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 configurations=./.modules/OpenTabletDriver/OpenTabletDriver/Configurations
 rules=./build/99-opentabletdriver.rules
 


### PR DESCRIPTION
I use fish as my shell and I could not run this script because the fish syntax differs from bash and other shells.
Adding a shebang will ensure bash is used to interpret the script.

Newline at end of file was added by editor.